### PR TITLE
add negative_prompt to self.pipe and self.image_pipe

### DIFF
--- a/app/serving_inference.py
+++ b/app/serving_inference.py
@@ -53,6 +53,7 @@ class FastStableDiffusion(FastInferenceInterface):
     def dispatch_request(self, args, env) -> Dict:
         try:
             prompt = args[0]["prompt"]
+            negative_prompt = args[0]["negative_prompt"]
             seed = args[0].get("seed")
             generator = torch.Generator(self.device).manual_seed(seed) if seed else None
             image_input = args[0].get("image_base64")
@@ -63,6 +64,7 @@ class FastStableDiffusion(FastInferenceInterface):
                 init_image.thumbnail((768, 768))
                 output = self.image_pipe(
                     prompt if isinstance(prompt, list) else [prompt],
+                    negative_prompt=negative_prompt if isinstance(negative_prompt, list) else [negative_prompt],
                     init_image=init_image,
                     generator=generator,
                     height=args[0].get("height", 512),
@@ -74,6 +76,7 @@ class FastStableDiffusion(FastInferenceInterface):
             else:
                 output = self.pipe(
                     prompt if isinstance(prompt, list) else [prompt],
+                    negative_prompt=negative_prompt if isinstance(negative_prompt, list) else [negative_prompt],
                     generator=generator,
                     height=args[0].get("height", 512),
                     width=args[0].get("width", 512),


### PR DESCRIPTION
This PR adds another "negative_prompt" input argument, in addition to the "prompt" input argument to the image models. 
```
docker run --rm --gpus device=7 \
  -p 5001:5001 \
  -e AUTH_TOKEN=${HUGGING_FACE_HUB_TOKEN} \
  -e SERVICE_DOMAIN=http \
  -e HTTP_HOST=0.0.0.0 \
  -e MODEL=stabilityai/stable-diffusion-xl-base-1.0 \
  -e MODEL_REVISION=main \
  -e HF_HOME=/home/user/.together/models \
  -v $PWD/.together:/home/user/.together \
  -it togethercomputer/stablediffusion:v1.0.2 python app/serving_inference.py
```

```
curl http://localhost:5001/ \
    -X POST \
    -H 'Content-Type: application/json' \
    -d '{"model": "StableDiffusion","prompt": "Tokyo crossing", "negative_prompt": "people", "n": 1, "steps": 20 }' 
```