### PR TITLE
Ubuntu 22.04 4core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ defaults:
 jobs:
   build:
     name: Build and push intermediate image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-4core
     outputs:
       tag: ${{ steps.build-image.outputs.tag }}
     steps:


### PR DESCRIPTION
updates run-on in workflows to specify our Ubuntu 22.04 4core runner to a maybe bigger build host