### PR TITLE
Updates for img2img models

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN pip install pytest matplotlib jupyter ipython ipdb gpustat scikit-learn spac
     && python -m spacy download en_core_web_sm
 
 # Core packages
-RUN pip install transformers==4.30.2 datasets==2.5.1
+RUN pip install transformers==4.30.2 datasets==2.5.1 accelerate
 
 # # Install FlashAttention
 RUN git clone https://github.com/togethercomputer/flash-attention \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,9 @@ RUN pip install pytest matplotlib jupyter ipython ipdb gpustat scikit-learn spac
 RUN pip install transformers==4.30.2 datasets==2.5.1 accelerate
 
 # # Install FlashAttention
-RUN git clone https://github.com/togethercomputer/flash-attention \
-    && cd flash-attention && pip install . \
-    && cd .. && rm -rf flash-attention
+RUN pip3 install --no-cache-dir \
+    'flash_attn @ git+https://github.com/Dao-AILab/flash-attention.git@v2.2.3' \
+    xformers
 
 # Install non-simd Pillow
 RUN pip install --upgrade Pillow

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-FROM 598726163780.dkr.ecr.us-west-2.amazonaws.com/together-node:latest AS together-node
 # Forked from https://github.com/tridao/zoo/blob/0c43127363a6bcf54ff200f215654e24e344f9ae/Dockerfile
 FROM nvcr.io/nvidia/pytorch:22.09-py3 as base
 
@@ -8,24 +7,32 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV TZ America/Los_Angeles
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 # git for installing dependencies
 # tzdata to set time zone
 # wget and unzip to download data
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     cmake \
+    coinor-cbc \
     curl \
     ca-certificates \
     sudo \
     less \
     htop \
     git \
+    python3-pip \
+    python3-dev \
     tzdata \
     wget \
     tmux \
     zip \
     unzip \
     && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://together-distro-packages.s3.us-west-2.amazonaws.com/linux/x86_64/bin/together-node-latest -O /usr/local/bin/together-node && \
+    chmod +x /usr/local/bin/together-node
 
 # All users can use /home/user as their home directory
 ENV HOME=/home/user
@@ -50,8 +57,9 @@ RUN pip3 install --no-cache-dir \
 # Install non-simd Pillow
 RUN pip install --upgrade Pillow
 
-COPY --from=together-node /usr/local/bin/together-node /usr/local/bin/
-COPY --from=together-node /usr/local/bin/together-node-update.sh /usr/local/bin/
+# Fix undefined symbol bug
+RUN pip uninstall transformer-engine -y
+
 COPY local-cfg.yaml /home/user/cfg.yaml
 COPY app app
 COPY serve.sh serve.sh

--- a/app/serving_inference.py
+++ b/app/serving_inference.py
@@ -6,68 +6,96 @@ from PIL import Image
 from typing import Dict
 import torch
 
-from diffusers import StableDiffusionPipeline, StableDiffusionImg2ImgPipeline, StableDiffusionXLPipeline
+from diffusers import (
+    StableDiffusionPipeline,
+    StableDiffusionImg2ImgPipeline,
+    StableDiffusionXLPipeline,
+    AutoPipelineForImage2Image,
+    AutoPipelineForInpainting,
+)
+from diffusers.utils import load_image
 from together_worker.fast_inference import FastInferenceInterface
 from together_web3.together import TogetherWeb3, TogetherClientOptions
-from together_web3.computer import ImageModelInferenceChoice, parse_tags, RequestTypeImageModelInference
+from together_web3.computer import (
+    ImageModelInferenceChoice,
+    parse_tags,
+    RequestTypeImageModelInference,
+)
 
 
 class FastStableDiffusion(FastInferenceInterface):
     def __init__(self, model_name: str, args=None) -> None:
         args = args if args is not None else {}
         super().__init__(model_name, args)
+
+        self.format = args.get("format", "JPEG")
+        self.device = args.get("device", "cuda")
+
         model_revision = os.environ.get("MODEL_REVISION", "fp16")
         if not model_revision or model_revision == "none":
             model_revision = None
+
         self.model = os.environ.get("MODEL", "runwayml/stable-diffusion-v1-5")
         print("init MODEL", self.model)
-        if(self.model == "stabilityai/stable-diffusion-xl-base-1.0"):
-            self.pipe = StableDiffusionXLPipeline.from_pretrained(
+
+        if self.model == "stabilityai/stable-diffusion-xl-base-1.0":
+            self.pipe_text2image = StableDiffusionXLPipeline.from_pretrained(
                 self.model,
-                torch_dtype=torch.float32,
+                torch_dtype=torch.float16,
                 revision=model_revision,
                 use_auth_token=args.get("auth_token"),
                 use_safetensors=True,
-                variant="fp16"
+                variant="fp16",
+                device_map="auto" if self.device == "cuda" else self.device,
             )
         else:
-            self.pipe = StableDiffusionPipeline.from_pretrained(
+            self.pipe_text2image = StableDiffusionPipeline.from_pretrained(
                 self.model,
                 torch_dtype=torch.float16,
                 revision=model_revision,
                 use_auth_token=args.get("auth_token"),
+                device_map="auto" if self.device == "cuda" else self.device,
             )
-        self.format = args.get("format", "JPEG")
-        self.device = args.get("device", "cuda")
-        self.pipe = self.pipe.to(self.device)
+
         self.options = parse_tags(os.environ.get("MODEL_OPTIONS"))
         self.inputs = self.options.get("input", "").split(",")
+
         if "image" in self.inputs:
-            self.image_pipe = StableDiffusionImg2ImgPipeline.from_pretrained(
-                os.environ.get("MODEL", "runwayml/stable-diffusion-v1-5"),
-                torch_dtype=torch.float16,
-                revision=model_revision,
-                use_auth_token=args.get("auth_token"),
+            # use from_pipe to avoid consuming additional memory when loading a checkpoint
+            self.pipe_image2image = AutoPipelineForImage2Image.from_pipe(
+                self.pipe_text2image
             ).to(self.device)
 
+        # Commenting out for now
+        # TODO: add support for inpainting
+        # if "inpainting" in self.inputs:
+        #    self.pipe_inpainting = AutoPipelineForInpainting.from_pipe(
+        #        self.pipe_text2image
+        #    ).to("cuda")
 
     def dispatch_request(self, args, env) -> Dict:
         try:
-            print('INVOKING:', self.model)
+            print("INVOKING:", self.model)
             print("ARGS:", args[0])
             prompt = args[0]["prompt"]
             negative_prompt = args[0].get("negative_prompt", None)
             if negative_prompt is not None:
-                negative_prompt = negative_prompt if isinstance(negative_prompt, list) else [negative_prompt]
+                negative_prompt = (
+                    negative_prompt
+                    if isinstance(negative_prompt, list)
+                    else [negative_prompt]
+                )
             seed = args[0].get("seed")
             generator = torch.Generator(self.device).manual_seed(seed) if seed else None
             image_input = args[0].get("image_base64")
             if image_input:
-                if not self.image_pipe:
+                if not self.pipe_image2image:
                     raise Exception("Image prompts not supported")
-                init_image = Image.open(BytesIO(base64.b64decode(image_input))).convert("RGB")
+
+                init_image = load_image(image_input).convert("RGB")
                 init_image.thumbnail((768, 768))
-                output = self.image_pipe(
+
+                output = self.pipe_image2image(
                     prompt if isinstance(prompt, list) else [prompt],
                     negative_prompt=negative_prompt,
                     image=init_image,
@@ -75,9 +103,10 @@ class FastStableDiffusion(FastInferenceInterface):
                     num_images_per_prompt=args[0].get("n", 1),
                     num_inference_steps=args[0].get("steps", 50),
                     guidance_scale=args[0].get("guidance_scale", 7.5),
+                    strength=args[0].get("strength", 0.75),  # must be between 0 and 1
                 )
             else:
-                output = self.pipe(
+                output = self.pipe_text2image(
                     prompt if isinstance(prompt, list) else [prompt],
                     negative_prompt=negative_prompt,
                     generator=generator,
@@ -91,7 +120,7 @@ class FastStableDiffusion(FastInferenceInterface):
             for image in output.images:
                 buffered = BytesIO()
                 image.save(buffered, format=args[0].get("format", self.format))
-                img_str = base64.b64encode(buffered.getvalue()).decode('ascii')
+                img_str = base64.b64encode(buffered.getvalue()).decode("ascii")
                 choices.append(ImageModelInferenceChoice(img_str))
             return {
                 "result_type": RequestTypeImageModelInference,
@@ -111,20 +140,29 @@ if __name__ == "__main__":
     coordinator = TogetherWeb3(
         TogetherClientOptions(reconnect=True),
         http_url=os.environ.get("COORD_HTTP_URL", f"http://{coord_url}:8092"),
-        websocket_url=os.environ.get("COORD_WS_URL", f"ws://{coord_url}:8093/websocket"),
+        websocket_url=os.environ.get(
+            "COORD_WS_URL", f"ws://{coord_url}:8093/websocket"
+        ),
     )
-    fip = FastStableDiffusion(model_name=os.environ.get("SERVICE", "StableDiffusion"), args={
-        "auth_token": os.environ.get("AUTH_TOKEN"),
-        "coordinator": coordinator,
-        "device": os.environ.get("DEVICE", "cuda"),
-        "format": os.environ.get("FORMAT", "JPEG"),
-        "gpu_num": 1 if torch.cuda.is_available() else 0,
-        "gpu_type": torch.cuda.get_device_name(0) if torch.cuda.is_available() else None,
-        "gpu_mem": torch.cuda.get_device_properties(0).total_memory if torch.cuda.is_available() else None,
-        "group_name": os.environ.get("GROUP", "group1"),
-        "http_host": os.environ.get("HTTP_HOST"),
-        "http_port": int(os.environ.get("HTTP_PORT", "5001")),
-        "service_domain": os.environ.get("SERVICE_DOMAIN", "together"),
-        "worker_name": os.environ.get("WORKER", "worker1"),
-    })
+    fip = FastStableDiffusion(
+        model_name=os.environ.get("SERVICE", "StableDiffusion"),
+        args={
+            "auth_token": os.environ.get("AUTH_TOKEN"),
+            "coordinator": coordinator,
+            "device": os.environ.get("DEVICE", "cuda"),
+            "format": os.environ.get("FORMAT", "JPEG"),
+            "gpu_num": 1 if torch.cuda.is_available() else 0,
+            "gpu_type": torch.cuda.get_device_name(0)
+            if torch.cuda.is_available()
+            else None,
+            "gpu_mem": torch.cuda.get_device_properties(0).total_memory
+            if torch.cuda.is_available()
+            else None,
+            "group_name": os.environ.get("GROUP", "group1"),
+            "http_host": os.environ.get("HTTP_HOST"),
+            "http_port": int(os.environ.get("HTTP_PORT", "5001")),
+            "service_domain": os.environ.get("SERVICE_DOMAIN", "together"),
+            "worker_name": os.environ.get("WORKER", "worker1"),
+        },
+    )
     fip.start()

--- a/app/serving_inference.py
+++ b/app/serving_inference.py
@@ -58,12 +58,14 @@ class FastStableDiffusion(FastInferenceInterface):
                 device_map="auto" if self.device == "cuda" else self.device,
             )
             self.pipe_text2image.enable_xformers_memory_efficient_attention()
-
-        # use from_pipe to avoid consuming additional memory when loading a checkpoint
-        self.pipe_image2image = AutoPipelineForImage2Image.from_pipe(
-            self.pipe_text2image
-        ).to(self.device)
-        self.pipe_image2image.enable_xformers_memory_efficient_attention()
+        self.options = parse_tags(os.environ.get("MODEL_OPTIONS"))
+        self.inputs = self.options.get("input", "").split(",")
+        if "image" in self.inputs:
+            # use from_pipe to avoid consuming additional memory when loading a checkpoint
+            self.pipe_image2image = AutoPipelineForImage2Image.from_pipe(
+                self.pipe_text2image
+            ).to(self.device)
+            self.pipe_image2image.enable_xformers_memory_efficient_attention()
 
         # Commenting out for now
         # TODO: add support for inpainting

--- a/app/serving_inference.py
+++ b/app/serving_inference.py
@@ -59,15 +59,11 @@ class FastStableDiffusion(FastInferenceInterface):
             )
             self.pipe_text2image.enable_xformers_memory_efficient_attention()
 
-        self.options = parse_tags(os.environ.get("MODEL_OPTIONS"))
-        self.inputs = self.options.get("input", "").split(",")
-
-        if "image" in self.inputs:
-            # use from_pipe to avoid consuming additional memory when loading a checkpoint
-            self.pipe_image2image = AutoPipelineForImage2Image.from_pipe(
-                self.pipe_text2image
-            ).to(self.device)
-            self.pipe_image2image.enable_xformers_memory_efficient_attention()
+        # use from_pipe to avoid consuming additional memory when loading a checkpoint
+        self.pipe_image2image = AutoPipelineForImage2Image.from_pipe(
+            self.pipe_text2image
+        ).to(self.device)
+        self.pipe_image2image.enable_xformers_memory_efficient_attention()
 
         # Commenting out for now
         # TODO: add support for inpainting
@@ -95,7 +91,7 @@ class FastStableDiffusion(FastInferenceInterface):
                 if not self.pipe_image2image:
                     raise Exception("Image prompts not supported")
 
-                init_image = load_image(image_input).convert("RGB")
+                init_image = Image.open(BytesIO(base64.b64decode(image_input))).convert("RGB")
                 init_image.thumbnail((768, 768))
 
                 output = self.pipe_image2image(

--- a/app/serving_inference.py
+++ b/app/serving_inference.py
@@ -48,6 +48,7 @@ class FastStableDiffusion(FastInferenceInterface):
                 variant="fp16",
                 device_map="auto" if self.device == "cuda" else self.device,
             )
+            self.pipe_text2image.enable_xformers_memory_efficient_attention()
         else:
             self.pipe_text2image = StableDiffusionPipeline.from_pretrained(
                 self.model,
@@ -56,6 +57,7 @@ class FastStableDiffusion(FastInferenceInterface):
                 use_auth_token=args.get("auth_token"),
                 device_map="auto" if self.device == "cuda" else self.device,
             )
+            self.pipe_text2image.enable_xformers_memory_efficient_attention()
 
         self.options = parse_tags(os.environ.get("MODEL_OPTIONS"))
         self.inputs = self.options.get("input", "").split(",")
@@ -65,6 +67,7 @@ class FastStableDiffusion(FastInferenceInterface):
             self.pipe_image2image = AutoPipelineForImage2Image.from_pipe(
                 self.pipe_text2image
             ).to(self.device)
+            self.pipe_image2image.enable_xformers_memory_efficient_attention()
 
         # Commenting out for now
         # TODO: add support for inpainting


### PR DESCRIPTION
The PR:
- simplifies initializing img2img pipeline so as not to take up 2x GPU memory by initializing with AutoPipelineForImage2Image.from_pipe
- Adds option for strength for img2img queries
- Fixes formatting with `black`

Example input:
![input-image](https://github.com/togethercomputer/StableDiffusion/assets/126978607/05245223-2c14-4b96-8b74-99e02305971a)

Prompt: "da vinci and water color style"

Example output:
![test-0](https://github.com/togethercomputer/StableDiffusion/assets/126978607/44a4fc18-3c98-483e-9520-d136544623eb)
